### PR TITLE
Remove old CouchBot link and premium references

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ A self host version of this bot will come out eventually. For more info, check o
 The CouchBot simple tutorial can be found in the CouchBot Wiki: https://github.com/dawgeth/CouchBot/wiki/Setup-Tutorial
 
 Twitter: http://twitter.com/mattthedev
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CouchBot
 
-[![Build status](https://mattthedev.visualstudio.com/CouchBot/_apis/build/status/Linux%20Release/CouchBot-ASP.NET%20Core-CI)](https://mattthedev.visualstudio.com/CouchBot/_build/latest?definitionId=2) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f37e6c619ab14e49acb5b2259db2fe6a)](https://www.codacy.com/app/MattTheDev/CouchBot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MattTheDev/CouchBot&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/f37e6c619ab14e49acb5b2259db2fe6a)](https://www.codacy.com/app/MattTheDev/CouchBot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MattTheDev/CouchBot&amp;utm_campaign=Badge_Grade)
 
 Let your Discord community know when you go live on Mixer (formerly Beam), Mobcrush, Smashcast (formerly Hitbox), Twitch, or YouTube Gaming! Want to let your friends know when you publish a new YouTube or Vid.me Video? Want to make a list of your favorite streamers, and get notified when they go live? CouchBot does that too!
 
@@ -13,8 +13,7 @@ Let your Discord community know when you go live on Mixer (formerly Beam), Mobcr
 6. YouTube and YouTube Gaming (http://youtube.com / http://gaming.youtube.com)
 
 **The Website**
-
-The code has been purged since becoming a premium bot. A self host version will come out eventually. For more info, check out http://couchbot.io.
+A self host version of this bot will come out eventually. For more info, check out http://couchbot.mattthedev.codes.
 
 **Simple Tutorial**: 
 The CouchBot simple tutorial can be found in the CouchBot Wiki: https://github.com/dawgeth/CouchBot/wiki/Setup-Tutorial


### PR DESCRIPTION
The former website couchbot.io is no longer under the control of @MattTheDev and is now reported to be malware, therefore it has been replaced with the other site. The bot is now also free, so references to premium have been removed.

Also, removed the build status because for some reason it's not set up. You can put it back after you do, though.